### PR TITLE
pkg: add repo details to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,14 @@
 	"main": "lib/index.js",
 	"author": "Daniel K. Bergey",
 	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/dbergey/babel-plugin-literate"
+	},
+	"homepage": "https://github.com/dbergey/babel-plugin-literate",
+	"bugs": {
+		"url": "https://github.com/dbergey/babel-plugin-literate/issues"
+	},
 	"scripts": {
 		"test": "jest"
 	},


### PR DESCRIPTION
## Summary

add repository, homepage, and bugs fields

## Details

- without these fields, the [NPM page](https://www.npmjs.com/package/babel-plugin-literate) effectively has no link to the source code, which could feel a bit sus
  - but the source code is right here on GitHub! so just link them together for clarity / explicitness